### PR TITLE
#20 #26 Espresso Thread Delay bug fix for TTS

### DIFF
--- a/app/src/androidTest/java/org/wikipedia/espresso/page/TTSReadingTest.java
+++ b/app/src/androidTest/java/org/wikipedia/espresso/page/TTSReadingTest.java
@@ -66,7 +66,7 @@ public class TTSReadingTest {
         // The recommended way to handle such scenarios is to use Espresso idling resources:
         // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
         try {
-            Thread.sleep(700);
+            Thread.sleep(7000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Simple fix potential crash caused by short thread sleep delay leading incompleted thread loading while processing next activity
Solution: increased first delay from 700ms to 7000ms